### PR TITLE
Ensure that no sensitive data leaks

### DIFF
--- a/specs/validation/Recovery.md
+++ b/specs/validation/Recovery.md
@@ -22,6 +22,8 @@ Validation of recovery DCCs.
 * Validate DCC
 * Check that the result is valid
 * Check that callback result is identical to polling result
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Recovery DCC with du before DoA is rejected
 * Reference "TXR-4218"
@@ -39,6 +41,8 @@ Validation of recovery DCCs.
 * Validate DCC
 * Check that the result is invalid
 * Check that callback result is identical to polling result
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 
 ## Recovery DCC with df after DoD is rejected
@@ -57,6 +61,8 @@ Validation of recovery DCCs.
 * Validate DCC
 * Check that the result is invalid
 * Check that callback result is identical to polling result
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Non-Covid-Recovery is rejected
 * Reference "TXR-4217"
@@ -75,3 +81,5 @@ Validation of recovery DCCs.
 * Validate DCC
 * Check that the result is invalid
 * Check that callback result is identical to polling result
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok

--- a/specs/validation/Vaccination.md
+++ b/specs/validation/Vaccination.md
@@ -20,6 +20,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-12-01"
 * Validate DCC
 * Check that the result is valid
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 
 ## Vaccination 2/2 from 3 days ago is invalid
@@ -36,6 +38,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-12-03"
 * Validate DCC
 * Check that the result is invalid
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 
 ## Expired vaccination DCC is invalid
@@ -50,7 +54,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-11-02"
 * Validate DCC
 * Check that the result is invalid
-
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Vaccination DCC signed with expired DSC is invalid
 * Reference "TXR-4203"
@@ -64,9 +69,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2024-11-02"
 * Validate DCC
 * Check that the result is invalid
-
-
-
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Vaccination 1/2 is invalid
 * Reference "TXR-4201"
@@ -84,7 +88,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-12-01"
 * Validate DCC
 * Check that the result is invalid
-
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Vaccination with unknown vaccine is invalid
 * Reference "TXR-4204"
@@ -102,6 +107,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-12-01"
 * Validate DCC
 * Check that the result is invalid
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Vaccination is rejected for issuance date in future
 * Reference "TXR-4213"
@@ -117,7 +124,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2022-03-01"
 * Validate DCC
 * Check that the result is invalid
-
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Vaccination is rejected for vaccination date in future
 * Reference "TXR-4212"
@@ -133,6 +141,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2022-03-01"
 * Validate DCC
 * Check that the result is invalid
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Non-Covid vaccination is rejected
 * Reference "TXR-4216"
@@ -149,6 +159,8 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-12-01"
 * Validate DCC
 * Check that the result is invalid
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok
 
 ## Vaccination is rejected for untrusted DSC
 * Reference "TXR-4214"
@@ -164,3 +176,5 @@ Validation of vaccination DCCs.
 * Set arrival date "2021-12-01"
 * Validate DCC
 * Check that the result is invalid
+* Check that the polling/callback result doesn't contain sensitive data
+* Check that the validate result contains infos or is ok

--- a/step_impl/validation/validation.py
+++ b/step_impl/validation/validation.py
@@ -271,6 +271,9 @@ def validate_dcc():
     assert response.ok
     #print(f'Validate result: {response.status_code}')
 
+    sc['validation:validation_response'] = jwt.decode(response.content, options={"verify_signature": False})
+    print("\n", sc['validation:validation_response']["result"], sc['validation:validation_response']["results"])
+
     headers = {"Authorization":"Bearer "+sc['statuskey'],"X-Version":"1.0"}
     response = requests.get(f"{validationServiceUrl}/status/{sc['subject']}", headers=headers )
     assert response.ok
@@ -293,3 +296,12 @@ def check_that_callback_result_is_identical_to_polling_result():
     assert response.ok
     callback_status = jwt.decode(response.content, options={"verify_signature":False})
     assert callback_status == sc['validation:status']
+
+@step("Check that the polling/callback result doesn't contain sensitive data")
+def check_that_results_are_empty_for_polling():
+    assert not data_store.scenario['validation:status']['results']
+
+@step("Check that the validate result contains infos or is ok")
+def check_that_the_validate_result_contains_infos_or_is_ok():
+    sc = data_store.scenario['validation:validation_response']
+    assert sc['result'] == 'OK' or sc['results']


### PR DESCRIPTION
Ensures that the reason why a DCC validation failed (the 'results' in the JWT) is being sent to the party who sent the DCC and to that party only.

@chrloch 
